### PR TITLE
Adding CWL 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,3 +21,6 @@ RUN   wget http://downloads.sourceforge.net/project/snpeff/snpEff_latest_core.zi
 # cleanup
 RUN   rm -rf v1.1.5.tar.gz snpEff_latest_core.zip snpEff/galaxy snpEff/examples 
 
+COPY radia.py /opt/
+COPY radia_filter.py /opt/
+RUN chmod +x /opt/radia*

--- a/radia.cwl.yaml
+++ b/radia.cwl.yaml
@@ -1,0 +1,454 @@
+#!/usr/bin/env cwl-runner
+#
+# Author: Jeltje van Baren jeltje.van.baren@gmail.com
+
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: [/opt/radia.py]
+
+doc: "Runs radia on individual chromosomes, then merges output. An input DNA (exome) sample pair is required, additional RNA-Seq data for the same sample is advised but optional. Radia performes significantly better when RNA data is added."
+
+hints:
+  DockerRequirement:
+    dockerPull: opengenomics/radia-tool
+
+requirements:
+  - class: InlineJavascriptRequirement
+
+inputs:
+  refseq:
+    type: File
+    doc: |
+      genome fasta file that was used to create the input bam files 
+    inputBinding:
+      position: 3
+      prefix: --fastaFilename
+# Note: It is possible to specify fasta files for each individual input, see below
+
+  dnaNormalFilename:
+    type: File
+    doc: |
+      the name of the normal DNA .bam file
+    inputBinding:
+      position: 3
+      prefix: --dnaNormalFilename
+
+  dnaNormalBaiFilename:
+    type: File
+    doc: |
+      the name of the normal DNA .bai file
+    inputBinding:
+      position: 3
+      prefix: --dnaNormalBaiFilename
+
+  dnaTumorFilename:
+    type: File
+    doc: |
+      the name of the tumor DNA .bam file
+    inputBinding:
+      position: 3
+      prefix: --dnaTumorFilename
+
+  dnaTumorBaiFilename:
+    type: File
+    doc: |
+      the name of the tumor DNA .bai file
+    inputBinding:
+      position: 3
+      prefix: --dnaTumorBaiFilename
+
+
+  out_vcf:
+    type: string
+    default: out.vcf
+    doc: |
+      the name of the output vcf (out.vcf)
+    inputBinding:
+      position: 3
+      prefix: --outputFilename
+
+  refId:
+    type: string?
+    doc: |
+      the reference Id - used in the reference VCF meta tag
+    inputBinding:
+      position: 3
+      prefix: --refId
+
+  outputDir:
+    type: string?
+    doc: |
+      the directory where temporary and final filtered output should be stored ('./')
+    inputBinding:
+      position: 3
+      prefix: --outputDir
+
+  patientId:
+    type: string?
+    doc: |
+      a unique patient Id that will be added to the SAMPLE and INDIVIDUAL tags in the vcf header (PATIENT)
+    inputBinding:
+      position: 3
+      prefix: --patientId
+
+  useChrPrefix:
+    type: boolean?
+    doc: |
+      this argument if the 'chr' prefix should be used in the samtools command for all bams (False)
+    inputBinding:
+      position: 3
+      prefix: --useChrPrefix
+
+  log:
+    type: string?
+    doc: |
+      the logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL) (WARNING)
+    inputBinding:
+      position: 3
+      prefix: --log
+
+  refUrl:
+    type: string?
+    doc: |
+      the URL for the reference - used in the reference VCF meta tag
+    inputBinding:
+      position: 3
+      prefix: --refUrl
+
+  refFilename:
+    type: string?
+    doc: |
+      the location of the reference - used in the reference VCF meta tag
+    inputBinding:
+      position: 3
+      prefix: --refFilename
+
+  statsDir:
+    type: string?
+    doc: |
+      a stats directory where some basic stats can be output
+    inputBinding:
+      position: 3
+      prefix: --statsDir
+
+  logFilename:
+    type: string?
+    doc: |
+      the name of the log file, STDOUT by default
+    inputBinding:
+      position: 3
+      prefix: --logFilename
+
+  batchSize:
+    type: int?
+    doc: |
+      the size of the samtools selections that are loaded into memory at one time (250000000)
+    inputBinding:
+      position: 3
+      prefix: --batchSize
+
+  dataSource:
+    type: string?
+    doc: |
+      the source of the data - used in the sample VCF meta tag
+    inputBinding:
+      position: 3
+      prefix: --dataSource
+
+  sequencingPlatform:
+    type: string?
+    doc: |
+      the sequencing platform - used in the sample VCF meta tag
+    inputBinding:
+      position: 3
+      prefix: --sequencingPlatform
+
+  disease:
+    type: string?
+    doc: |
+      a disease abbreviation (i.e. BRCA) for the header
+    inputBinding:
+      position: 3
+      prefix: --disease
+
+  genotypeMinDepth:
+    type: int?
+    doc: |
+      the minimum number of bases required for the genotype (2)
+    inputBinding:
+      position: 3
+      prefix: --genotypeMinDepth
+
+  genotypeMinPct:
+    type: float?
+    doc: |
+      the minimum percentage of reads required for the genotype (.10)
+    inputBinding:
+      position: 3
+      prefix: --genotypeMinPct
+
+  gzip:
+    type: boolean?
+    doc: |
+      this argument if the final VCF should be compressed with gzip (False)
+    inputBinding:
+      position: 3
+      prefix: --gzip
+
+  rnaNormalFilename:
+    type: File?
+    doc: |
+      the name of the normal RNA-Seq .bam file
+    inputBinding:
+      position: 3
+      prefix: --rnaNormalFilename
+
+  rnaNormalBaiFilename:
+    type: File?
+    doc: |
+      the name of the normal RNA-Seq .bai file
+    inputBinding:
+      position: 3
+      prefix: --rnaNormalBaiFilename
+
+  rnaTumorFilename:
+    type: File?
+    doc: |
+      the name of the tumor RNA-Seq .bam file
+    inputBinding:
+      position: 3
+      prefix: --rnaTumorFilename
+
+  rnaTumorBaiFilename:
+    type: File?
+    doc: |
+      the name of the tumor RNA-Seq .bai file
+    inputBinding:
+      position: 3
+      prefix: --rnaTumorBaiFilename
+
+  dnaNormalMinTotalBases:
+    type: int?
+    doc: |
+      the minimum number of overall normal DNA reads covering a position (4)
+    inputBinding:
+      position: 3
+      prefix: --dnaNormalMinTotalBases
+
+  dnaNormalMinAltBases:
+    type: int?
+    doc: |
+      the minimum number of alternative normal DNA reads supporting a variant at a position (2)
+    inputBinding:
+      position: 3
+      prefix: --dnaNormalMinAltBases
+
+  dnaNormalBaseQual:
+    type: int?
+    doc: |
+      the minimum normal DNA base quality (10)
+    inputBinding:
+      position: 3
+      prefix: --dnaNormalBaseQual
+
+  dnaNormalMapQual:
+    type: int?
+    doc: |
+      the minimum normal DNA mapping quality (10)
+    inputBinding:
+      position: 3
+      prefix: --dnaNormalMapQual
+
+  dnaNormalFasta:
+    type: File?
+    doc: |
+      the name of the genome fasta file for the normal DNA .bam file
+    inputBinding:
+      position: 3
+      prefix: --dnaNormalFasta
+
+  dnaNormalDescription:
+    type: string?
+    doc: |
+      the description for the sample in the VCF header (NormalDNASample)
+    inputBinding:
+      position: 3
+      prefix: --dnaNormalDescription
+
+  rnaNormalMinTotalBases:
+    type: int?
+    doc: |
+      the minimum number of overall normal RNA-Seq reads covering a position (4)
+    inputBinding:
+      position: 3
+      prefix: --rnaNormalMinTotalBases
+
+  rnaNormalMinAltBases:
+    type: int?
+    doc: |
+      the minimum number of alternative normal RNA-Seq reads supporting a variant at a position (2)
+    inputBinding:
+      position: 3
+      prefix: --rnaNormalMinAltBases
+
+  rnaNormalBaseQual:
+    type: int?
+    doc: |
+      the minimum normal RNA-Seq base quality (10)
+    inputBinding:
+      position: 3
+      prefix: --rnaNormalBaseQual
+
+  rnaNormalMapQual:
+    type: int?
+    doc: |
+      the minimum normal RNA-Seq mapping quality (10)
+    inputBinding:
+      position: 3
+      prefix: --rnaNormalMapQual
+
+  rnaNormalFasta:
+    type: File?
+    doc: |
+      the name of the fasta file for the normal RNA .bam file
+    inputBinding:
+      position: 3
+      prefix: --rnaNormalFasta
+
+  rnaNormalDescription:
+    type: string?
+    doc: |
+      the description for the sample in the VCF header (NormalRNASample)
+    inputBinding:
+      position: 3
+      prefix: --rnaNormalDescription
+
+  dnaTumorMinTotalBases:
+    type: int?
+    doc: |
+      the minimum number of overall tumor DNA reads covering a position (4)
+    inputBinding:
+      position: 3
+      prefix: --dnaTumorMinTotalBases
+
+  dnaTumorMinAltBases:
+    type: int?
+    doc: |
+      the minimum number of alternative tumor DNA reads supporting a variant at a position (2)
+    inputBinding:
+      position: 3
+      prefix: --dnaTumorMinAltBases
+
+  dnaTumorBaseQual:
+    type: int?
+    doc: |
+      the minimum tumor DNA base quality (10)
+    inputBinding:
+      position: 3
+      prefix: --dnaTumorBaseQual
+
+  dnaTumorMapQual:
+    type: int?
+    doc: |
+      the minimum tumor DNA mapping quality (10)
+    inputBinding:
+      position: 3
+      prefix: --dnaTumorMapQual
+
+  dnaTumorFasta:
+    type: File?
+    doc: |
+      the name of the fasta file for the tumor DNA .bam file
+    inputBinding:
+      position: 3
+      prefix: --dnaTumorFasta
+
+  dnaTumorDescription:
+    type: string?
+    doc: |
+      the description for the sample in the VCF header (TumorDNASample)
+    inputBinding:
+      position: 3
+      prefix: --dnaTumorDescription
+
+  rnaTumorMinTotalBases:
+    type: int?
+    doc: |
+      the minimum number of overall tumor RNA-Seq reads covering a position (4)
+    inputBinding:
+      position: 3
+      prefix: --rnaTumorMinTotalBases
+
+  rnaTumorMinAltBases:
+    type: int?
+    doc: |
+      the minimum number of alternative tumor RNA-Seq reads supporting a variant at a position (2)
+    inputBinding:
+      position: 3
+      prefix: --rnaTumorMinAltBases
+
+  rnaTumorBaseQual:
+    type: int?
+    doc: |
+      the minimum tumor RNA-Seq base quality (10)
+    inputBinding:
+      position: 3
+      prefix: --rnaTumorBaseQual
+
+  rnaTumorMapQual:
+    type: int?
+    doc: |
+      the minimum tumor RNA-Seq mapping quality (10)
+    inputBinding:
+      position: 3
+      prefix: --rnaTumorMapQual
+
+  rnaTumorFasta:
+    type: File?
+    doc: |
+      the name of the fasta file for the tumor RNA .bam file
+    inputBinding:
+      position: 3
+      prefix: --rnaTumorFasta
+
+  rnaTumorDescription:
+    type: string?
+    doc: |
+      the description for the sample in the VCF header (TumorRNASample)
+    inputBinding:
+      position: 3
+      prefix: --rnaTumorDescription
+
+  number_of_procs:
+    type: int?
+    doc: |
+      number of cpus to use (1)
+    inputBinding:
+      position: 3
+      prefix: --number_of_procs
+
+  workdir:
+    type: string?
+    doc: |
+      working directory to use (./)
+    inputBinding:
+      position: 3
+      prefix: --workdir
+
+  no_clean:
+    type: boolean?
+    doc: |
+      do not remove intermediate files (False)
+    inputBinding:
+      position: 3
+      prefix: --no_clean
+
+
+outputs:
+
+  mutations:
+    type: File
+    outputBinding:
+       glob: $(inputs.out_vcf)
+
+

--- a/radia_filter.cwl.yaml
+++ b/radia_filter.cwl.yaml
@@ -1,0 +1,315 @@
+#!/usr/bin/env cwl-runner
+#
+# Author: Jeltje van Baren jeltje.van.baren@gmail.com
+
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: [/opt/radia_filter.py]
+
+doc: "Filter radia output. If the input is from exomes plus RNA-Seq, set dnaOnly to False"
+
+hints:
+  DockerRequirement:
+    dockerPull: opengenomics/radia-tool
+
+requirements:
+  - class: InlineJavascriptRequirement
+
+inputs:
+
+  inputVCF:
+    type: File
+    doc: |
+      The input Radia vcf file
+    inputBinding:
+      position: 2
+      prefix: --inputVCF
+
+  patientId:
+    type: string
+    doc: |
+      a unique patient Id that will be used to name the output file
+    inputBinding:
+      position: 2
+      prefix: --patientId
+
+  refseq:
+    type: File
+    doc: |
+      genome fasta file that was used to create the input bam files
+    inputBinding:
+      position: 2
+      prefix: --fastaFilename
+
+  dnaNormalFilename:
+    type: File
+    doc: |
+      the name of the normal DNA .bam file
+    inputBinding:
+      position: 2
+      prefix: --dnaNormalFilename
+
+  dnaNormalBaiFilename:
+    type: File
+    doc: |
+      the name of the normal DNA .bai file
+    inputBinding:
+      position: 2
+      prefix: --dnaNormalBaiFilename
+
+  dnaTumorFilename:
+    type: File
+    doc: |
+      the name of the tumor DNA .bam file
+    inputBinding:
+      position: 2
+      prefix: --dnaTumorFilename
+
+  dnaTumorBaiFilename:
+    type: File
+    doc: |
+      the name of the tumor DNA .bai file
+    inputBinding:
+      position: 2
+      prefix: --dnaTumorBaiFilename
+
+  out_vcf:
+    type: string
+    default: filtered_out.vcf
+    doc: |
+      the name of the output file
+    inputBinding:
+      position: 2
+      prefix: --outputFilename
+
+  outputDir:
+    type: string?
+    doc: |
+      the directory where temporary and final filtered output should be stored (default ./)
+    inputBinding:
+      position: 2
+      prefix: --outputDir
+
+  makeTCGAcompliant:
+    type: boolean
+    default: true
+    doc: |
+      Change VCF to make TCGA v1.1 compliant. This changes a lot in the VCF header and corrects the body (True)
+    inputBinding:
+      position: 2
+      prefix: --makeTCGAcompliant
+
+  filter-rejects:
+    type: boolean
+    default: true
+    doc: |
+      Filter out rejected calls (True)
+    inputBinding:
+      position: 2
+      prefix: --filter-rejects
+
+  filter-germline:
+    type: boolean
+    default: true
+    doc: |
+      Filter out germline calls (True)
+    inputBinding:
+      position: 2
+      prefix: --filter-germline
+
+
+  dnaNormalFastaFilename:
+    type: File?
+    doc: |
+      the name of the fasta file that was used to create the BAM alignments
+    inputBinding:
+      position: 2
+      prefix: --dnaNormalFastaFilename
+
+  dnaTumorFastaFilename:
+    type: File?
+    doc: |
+      the name of the fasta file that was used to create the BAM alignments
+    inputBinding:
+      position: 2
+      prefix: --dnaTumorFastaFilename
+
+  rnaNormalFilename:
+    type: File?
+    doc: |
+      the name of the normal RNA .bam file
+    inputBinding:
+      position: 2
+      prefix: --rnaNormalFilename
+
+  rnaNormalBaiFilename:
+    type: File?
+    doc: |
+      the name of the normal RNA .bai file
+    inputBinding:
+      position: 2
+      prefix: --rnaNormalBaiFilename
+
+  rnaNormalFastaFilename:
+    type: File?
+    doc: |
+      the name of the fasta file that was used to create the BAM alignments
+    inputBinding:
+      position: 2
+      prefix: --rnaNormalFastaFilename
+
+  rnaTumorFilename:
+    type: File?
+    doc: |
+      the name of the tumor RNA .bam file
+    inputBinding:
+      position: 2
+      prefix: --rnaTumorFilename
+
+  rnaTumorBaiFilename:
+    type: File?
+    doc: |
+      the name of the tumor RNA .bai file
+    inputBinding:
+      position: 2
+      prefix: --rnaTumorBaiFilename
+
+  rnaTumorFastaFilename:
+    type: File?
+    doc: |
+      the name of the fasta file that was used to create the BAM alignments
+    inputBinding:
+      position: 2
+      prefix: --rnaTumorFastaFilename
+
+  blacklistFilename:
+    type: File?
+    doc: |
+      the name of the blacklist bed file
+    inputBinding:
+      position: 2
+      prefix: --blacklistFilename
+
+  targetFilename:
+    type: File?
+    doc: |
+      the name of the exon capture targets file
+    inputBinding:
+      position: 2
+      prefix: --targetFilename
+
+  snpFilename:
+    type: File?
+    doc: |
+      dbSNP vcf file
+    inputBinding:
+      position: 2
+      prefix: --snpFilename
+
+  retroGenesFilename:
+    type: File?
+    doc: |
+      the name of the retrogenes bed file
+    inputBinding:
+      position: 2
+      prefix: --retroGenesFilename
+
+  pseudoGenesFilename:
+    type: File?
+    doc: |
+      the name of the pseudogenes bed file
+    inputBinding:
+      position: 2
+      prefix: --pseudoGenesFilename
+
+  cosmicFilename:
+    type: File?
+    doc: |
+      the name of the Catalogue Of Somatic Mutations In Cancer (COSMIC) annotations file
+    inputBinding:
+      position: 2
+      prefix: --cosmicFilename
+
+  canonical:
+    type: boolean?
+    doc: |
+      include this argument if only the canonical transcripts from snpEff should be used (False)
+    inputBinding:
+      position: 2
+      prefix: --canonical
+
+  rnaGeneBlckFile:
+    type: File?
+    doc: |
+      the RNA gene blacklist file
+    inputBinding:
+      position: 2
+      prefix: --rnaGeneBlckFile
+
+  rnaGeneFamilyBlckFile:
+    type: File?
+    doc: |
+      the RNA gene family blacklist file
+    inputBinding:
+      position: 2
+      prefix: --rnaGeneFamilyBlckFile
+
+  blatFastaFilename:
+    type: File?
+    doc: |
+      the fasta file that can be used during the BLAT filtering
+    inputBinding:
+      position: 2
+      prefix: --blatFastaFilename
+
+  noPositionalBias:
+    type: boolean?
+    doc: |
+      include this argument if the positional bias filter should not be applied (False)
+    inputBinding:
+      position: 2
+      prefix: --noPositionalBias
+
+  dnaOnly:
+    type: boolean
+    default: True
+    doc: |
+      this argument if you only have DNA or filtering should only be done on the DNA (True)
+    inputBinding:
+      position: 2
+      prefix: --dnaOnly
+
+  number_of_procs:
+    type: int?
+    doc: |
+      number of cpus to use (8)
+    inputBinding:
+      position: 2
+      prefix: --number_of_procs
+
+  workdir:
+    type: string?
+    doc: |
+      work dir (./)
+    inputBinding:
+      position: 2
+      prefix: --workdir
+
+  no_clean:
+    type: boolean?
+    doc: |
+      do not remove intermediate files (False)
+    inputBinding:
+      position: 2
+      prefix: --no_clean
+
+
+outputs:
+
+  mutations:
+    type: File
+    outputBinding:
+       glob: $(inputs.out_vcf)
+
+
+

--- a/radia_filter.cwl.yaml
+++ b/radia_filter.cwl.yaml
@@ -282,7 +282,7 @@ inputs:
   number_of_procs:
     type: int?
     doc: |
-      number of cpus to use (8)
+      number of cpus to use (1)
     inputBinding:
       position: 2
       prefix: --number_of_procs

--- a/radia_filter.py
+++ b/radia_filter.py
@@ -780,7 +780,7 @@ def __main__():
 
 
     # some extra stuff
-    parser.add_argument('--number_of_procs', dest='procs', type=int, default=8)
+    parser.add_argument('--number_of_procs', dest='procs', type=int, default=1)
     parser.add_argument('--workdir', default="./")
     parser.add_argument('--no_clean', action="store_true", default=False)
 
@@ -866,7 +866,8 @@ def __main__():
                 if execute(cmd):
                     raise Exception("RadiaFilter Call failed")
                 if not correctLineCount(chromLines[chrom], outfile):
-                    raise Exception("RadiaFilter sanity check failed")
+                    errmsg = "RadiaFilter sanity check failed on chrom %s\n" % (chrom)
+                    raise Exception(errmsg)
                 with open(logFile, 'r') as f:
                     print >>sys.stderr, f.read()
         else:

--- a/radia_filter.py
+++ b/radia_filter.py
@@ -887,7 +887,8 @@ def __main__():
                 with open(logFile, 'r') as f:
                     print >>sys.stderr, f.read()
                 if not correctLineCount(chromLines[chrom], rawOuts[chrom]):
-                    raise Exception("RadiaFilter sanity check failed")
+                    errmsg = "RadiaFilter sanity check failed on chrom %s\n" % (chrom)
+                    raise Exception(errmsg)
 
         # the radiaMerge command only uses the output directory and patient name
         cmd, mergeOut = radiaMerge(args, tempDir)

--- a/radia_filter.py
+++ b/radia_filter.py
@@ -732,9 +732,9 @@ def __main__():
     #############################
     parser.add_argument("--inputVCF", dest="inputVCF", required=True, metavar="INPUT_VCF", help="The input Radia vcf file")
     parser.add_argument("--patientId", dest="patientId", required=True, metavar="PATIENT_ID", help="a unique patient Id that will be used to name the output file")
-    parser.add_argument("-o", "--outputFilename", dest="outputFilename", required=True, metavar="OUTPUT_FILE", default='out.vcf', help="the name of the output file")
-    parser.add_argument("--outputDir", dest="outputDir", required=True, metavar="FILTER_OUT_DIR", help="the directory where temporary and final filtered output should be stored")
-    parser.add_argument("--scriptsDir", dest="scriptsDir", required=True, metavar="SCRIPTS_DIR", help="the directory that contains the RADIA filter scripts")
+    parser.add_argument("-o", "--outputFilename", dest="outputFilename", default="filtered_out.vcf", metavar="OUTPUT_FILE", help="the name of the output file (filtered_out.vcf)")
+    parser.add_argument("--outputDir", dest="outputDir", default='./', metavar="FILTER_OUT_DIR", help="the directory where temporary and final filtered output should be stored")
+    parser.add_argument("--scriptsDir", dest="scriptsDir", default='/opt/radia-1.1.5/scripts', metavar="SCRIPTS_DIR", help="the directory that contains the RADIA filter scripts")
     parser.add_argument("-f", "--fastaFilename", dest="fastaFilename", metavar="FASTA_FILE", help="the name of the fasta file that can be used on all .bams, see below for specifying individual fasta files for each .bam file")
     parser.add_argument("--makeTCGAcompliant", action="store_true", default=False, dest="makeTCGAcompliant", help="Change VCF to make TCGA v1.1 compliant")
     parser.add_argument("--filter-rejects", action="store_true", default=False, dest="filterRejects", help="Filter out rejected calls")
@@ -766,9 +766,9 @@ def __main__():
     parser.add_argument("--retroGenesFilename", dest="retroGenesFilename", metavar="RETRO_FILE", help="the name of the retrogenes bed file")
     parser.add_argument("--pseudoGenesFilename", dest="pseudoGenesFilename", metavar="PSEUDO_FILE", help="the name of the pseudogenes bed file")
     parser.add_argument("--cosmicFilename", dest="cosmicFilename", metavar="COSMIC_FILE", help="the name of the Catalogue Of Somatic Mutations In Cancer (COSMIC) annotations file")
-    parser.add_argument("--snpEffDir", dest="snpEffDir", metavar="SNP_EFF_DIR", help="the path to the snpEff directory")
+    parser.add_argument("--snpEffDir", dest="snpEffDir", default='/opt/snpEff', metavar="SNP_EFF_DIR", help="the path to the snpEff directory")
     parser.add_argument("--snpEffFilename", dest="snpEffFilename", metavar="SNP_EFF_FILE", help="the snpEff input database zip file")
-    parser.add_argument("--canonical", action="store_true", default=False, dest="canonical", help="include this argument if only the canonical transcripts from snpEff should be used, %default by default")
+    parser.add_argument("--canonical", action="store_true", default=False, dest="canonical", help="include this argument if only the canonical transcripts from snpEff should be used")
     parser.add_argument("--rnaGeneBlckFile", dest="rnaGeneBlckFile", metavar="RNA_GENE_FILE", help="the RNA gene blacklist file")
     parser.add_argument("--rnaGeneFamilyBlckFile", dest="rnaGeneFamilyBlckFile", metavar="RNA_GENE_FAMILY_FILE", help="the RNA gene family blacklist file")
     parser.add_argument("--blatFastaFilename", dest="blatFastaFilename", metavar="FASTA_FILE", help="the fasta file that can be used during the BLAT filtering")
@@ -780,7 +780,7 @@ def __main__():
 
 
     # some extra stuff
-    parser.add_argument('--number_of_procs', dest='procs', type=int, default=1)
+    parser.add_argument('--number_of_procs', dest='procs', type=int, default=8)
     parser.add_argument('--workdir', default="./")
     parser.add_argument('--no_clean', action="store_true", default=False)
 
@@ -886,7 +886,7 @@ def __main__():
                 with open(logFile, 'r') as f:
                     print >>sys.stderr, f.read()
                 if not correctLineCount(chromLines[chrom], rawOuts[chrom]):
-                    sys.stderr.write("RadiaFilter sanity check failed on chrome %s\n" % (chrom))
+                    raise Exception("RadiaFilter sanity check failed")
 
         # the radiaMerge command only uses the output directory and patient name
         cmd, mergeOut = radiaMerge(args, tempDir)


### PR DESCRIPTION
This PR adds CWL for radia.py and radia_filter.py and puts both scripts on the radia-tool docker container

Other changes:
- Changed `%default by default` in option help strings (it doesn't work) to the actual default values of each parameter
- Removed the `<nnn>UseChr` parameter as it was set during the `radia.py` run (it didn't work as expected)
- Set some docker specific defaults for script locations
- Changed the default output of `radia_filter.py` to `filtered_out.vcf` to distinguish from radia's `out.vcf`.