### PR TITLE
 Making code Dockstore compatible

### DIFF
--- a/Dockstore.json
+++ b/Dockstore.json
@@ -1,0 +1,27 @@
+{
+  "refseq": {
+    "path": "http://hgwdev.cse.ucsc.edu/~jeltje/public_data/genome.fa.gz",
+    "class": "File"
+  },
+  "number_of_procs": 2,
+  "dnaTumorFilename": {
+    "path": "https://dcc.icgc.org/api/v1/download?fn=/PCAWG/reference_data/data_for_testing/HCC1143_ds/HCC1143.bam",
+    "class": "File"
+  },
+  "dnaTumorBaiFilename": {
+    "path": "https://dcc.icgc.org/api/v1/download?fn=/PCAWG/reference_data/data_for_testing/HCC1143_ds/HCC1143.bam.bai",
+    "class": "File"
+  },
+  "dnaNormalFilename": {
+    "path": "https://dcc.icgc.org/api/v1/download?fn=/PCAWG/reference_data/data_for_testing/HCC1143_ds/HCC1143_BL.bam",
+    "class": "File"
+  },
+  "dnaNormalBaiFilename": {
+    "path": "https://dcc.icgc.org/api/v1/download?fn=/PCAWG/reference_data/data_for_testing/HCC1143_ds/HCC1143_BL.bam.bai",
+    "class": "File"
+  },
+  "mutations": {
+    "path": "/mnt/radia.vcf",
+    "class": "File"
+  }
+}

--- a/radia.cwl
+++ b/radia.cwl
@@ -10,7 +10,7 @@ doc: "Runs radia on individual chromosomes, then merges output. An input DNA (ex
 
 hints:
   DockerRequirement:
-    dockerPull: opengenomics/radia-tool
+    dockerPull: quay.io/opengenomics/radia
 
 requirements:
   - class: InlineJavascriptRequirement
@@ -85,8 +85,9 @@ inputs:
 
   patientId:
     type: string?
+    default: myPatient
     doc: |
-      a unique patient Id that will be added to the SAMPLE and INDIVIDUAL tags in the vcf header (PATIENT)
+      a unique patient Id that will be added to the SAMPLE and INDIVIDUAL tags in the vcf header (myPatient)
     inputBinding:
       position: 3
       prefix: --patientId

--- a/radia_filter.cwl
+++ b/radia_filter.cwl
@@ -10,7 +10,7 @@ doc: "Filter radia output. If the input is from exomes plus RNA-Seq, set dnaOnly
 
 hints:
   DockerRequirement:
-    dockerPull: opengenomics/radia-tool
+    dockerPull: quay.io/opengenomics/radia
 
 requirements:
   - class: InlineJavascriptRequirement


### PR DESCRIPTION
This PR includes the following changes:

- upgrade cwl to v1.0 and rename to `cwl` to make compatible with Dockstore
- add test input `json` file with publicly available data
- change default docker container to quay.io